### PR TITLE
Use NSKeyedArchiver instead of NSJSONSerialization

### DIFF
--- a/Example/MMWormhole/MMWormhole/ViewController.m
+++ b/Example/MMWormhole/MMWormhole/ViewController.m
@@ -47,8 +47,8 @@
 - (IBAction)segmentedControlValueDidChange:(UISegmentedControl *)segmentedControl {
     NSString *title = [segmentedControl titleForSegmentAtIndex:segmentedControl.selectedSegmentIndex];
     
-    // Pass a message for the selection identifier. The message itself is a JSON object with a single
-    // value and key called selectionString.
+    // Pass a message for the selection identifier. The message itself is a NSCoding compliant object
+    // with a single value and key called selectionString.
     [self.wormhole passMessageObject:@{@"selectionString" : title} identifier:@"selection"];
 }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MMWormhole
 
-MMWormhole creates a bridge between an iOS extension and it's containing application. The wormhole is meant to be used to pass data or commands back and forth between the two locations. Messages are passed as JSON files which are written to the application's shared App Group. The effect closely resembles interprocess communication between the app and the extension, though true interprocess communication does not exist between extensions and containing apps. 
+MMWormhole creates a bridge between an iOS extension and it's containing application. The wormhole is meant to be used to pass data or commands back and forth between the two locations. Messages are archived to files which are written to the application's shared App Group. The effect closely resembles interprocess communication between the app and the extension, though true interprocess communication does not exist between extensions and containing apps. 
 
 The wormhole also supports CFNotificationCenter Darwin Notifications in an effort to support realtime change notifications. When a message is passed to the wormhole, interested parties can listen and be notified of these changes on either side of the wormhole. The effect is nearly instant updates on either side when a message is sent through the wormhole.
 
@@ -44,9 +44,9 @@ MMWormhole is designed to make it easy to share very basic information and comma
 
 A good way to think of the wormhole is a collection of shared mailboxes. An identifier is essentially a unique mailbox you can send messages to. You know where a message will be delivered to because of the identifier you associate with it, but not necessarily when the message will be picked up by the recipient. If the app or extension are in the background, they may not receive the message immediately. By convention, sending messages should be done from one side to another, not necessarily from yourself to yourself. It's also a good practice to check the contents of your mailbox when your app or extension wakes up, in case any messages have been left there while you were away.
 
-The decision to use JSON files as the message passing medium also reflects the relatively simple nature of Today Extensions and WatchKit Extensions. For many apps, sharing simple strings or numbers is sufficient to drive the UI of a Widget or Apple Watch app. JSON is also a well understood and easy to use medium, which makes it both easy to debug and easy to use even when the containing app isn't running concurrently with the extension. Messages can be sent and persisted easily as JSON files and read later when the app or extension is woken up later.
+MMWormhole uses NSKeyedArchiver as a serialization medium, so any object that is NScoding compliant can work as a message. For many apps, sharing simple strings or numbers is sufficient to drive the UI of a Widget or Apple Watch app. Messages can be sent and persisted easily as archive files and read later when the app or extension is woken up later.
 
-Using MMWormhole is extremely straightforward. The only real catch is that your app and it's extensions must support shared app groups. The group will be used for writing the JSON files that represent each message. While larger files and structures, including a whole Core Data database, can be shared using App Groups, MMWormhole is designed to use it's own directory simply to pass messages. Because of that, a best practice is to initialize MMWormhole with a directory name that it will use within your app's shared App Group.
+Using MMWormhole is extremely straightforward. The only real catch is that your app and it's extensions must support shared app groups. The group will be used for writing the archive files that represent each message. While larger files and structures, including a whole Core Data database, can be shared using App Groups, MMWormhole is designed to use it's own directory simply to pass messages. Because of that, a best practice is to initialize MMWormhole with a directory name that it will use within your app's shared App Group.
 
 ### Initialization
 
@@ -59,7 +59,7 @@ self.wormhole = [[MMWormhole alloc] initWithApplicationGroupIdentifier:@"group.c
 
 ### Passing a Message
 
-Pass a message with an identifier for the message and a JSON object as the message itself
+Pass a message with an identifier for the message and a NSCoding compliant object as the message itself
 
 ```objective-c
 [self.wormhole passMessageObject:@{@"titleString" : title} 

--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -40,8 +40,8 @@
  were away.
  
  Passing a message to the wormhole can be inferred as a data transfer package or as a command. In
- both cases, the passed message is written as a JSON object to a .json file named with the
- included identifier. As a data transfer, the contents of written .json file can be queried using
+ both cases, the passed message is archived using NSKeyedArchiver to a .archive file named with the
+ included identifier. As a data transfer, the contents of the written .archive file can be queried using
  the messageWithIdentifier: method. As a command, the simple existence of the message in the shared
  app group should be taken as proof of the command's invocation. The contents of the message then
  become parameters to be evaluated along with the command. Of course, to avoid confusion later, it
@@ -53,8 +53,8 @@
  extension. When a message is passed with an identifier, a notification is fired to the Darwin 
  Notification Center with the given identifier. If you have indicated your interest in the message
  by using the -listenForMessageWithIdentifier:completion: method then your completion block will be
- called when this notification is received, and the contents of the message will be passed as a JSON
- object to the completion block.
+ called when this notification is received, and the contents of the message will be unarchived and
+ passed as an object to the completion block.
  
  It's worth noting that as a best practice to avoid confusing issues or deadlock that messages
  should be passed one way only for a given identifier. The containing app should pass messages to
@@ -86,14 +86,14 @@
  listener for a "finished changing" message to let the other side know it's safe to read the 
  contents of your message.
  
- @param messageobject The JSON message object to be passed
+ @param messageobject The message object to be passed
  @param identifier The identifier for the message
  */
 - (void)passMessageObject:(id)messageObject
                identifier:(NSString *)identifier;
 
 /**
- This method returns the value of a message with a specific identifier as a JSON object.
+ This method returns the value of a message with a specific identifier as an object.
  
  @param identifier The identifier for the message
  */
@@ -116,14 +116,14 @@
 /**
  This method begins listening for notifications of changes to a message with a specific identifier.
  If notifications are observed then the given listener block will be called along with the actual
- message as a JSON object.
+ message object.
  
  @discussion This class only supports one listener per message identifier, so calling this method
  repeatedly for the same identifier will update the listener block that will be called when a
  message is heard.
  
  @param identifier The identifier for the message
- @param listener A listener block called with the JSON messageObject parameter when a notification
+ @param listener A listener block called with the messageObject parameter when a notification
  is observed.
  */
 - (void)listenForMessageWithIdentifier:(NSString *)identifier

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -88,7 +88,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
 
 - (NSString *)filePathForIdentifier:(NSString *)identifier {
     NSString *directoryPath = [self messagePassingDirectoryPath];
-    NSString *fileName = [NSString stringWithFormat:@"%@.json", identifier];
+    NSString *fileName = [NSString stringWithFormat:@"%@.archive", identifier];
     NSString *filePath = [directoryPath stringByAppendingPathComponent:fileName];
     
     return filePath;
@@ -99,9 +99,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
         return;
     }
     
-    NSData *data = [NSJSONSerialization dataWithJSONObject:messageObject
-                                                   options:NSJSONWritingPrettyPrinted
-                                                     error:NULL];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:messageObject];
     
     if (data == nil) {
         return;
@@ -125,7 +123,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
         return nil;
     }
     
-    id messageObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    id messageObject = [NSKeyedUnarchiver unarchiveObjectWithData:data];
     
     return messageObject;
 }


### PR DESCRIPTION
NSCoding is the standard serialization protocol in iOS and OS X, so this gives users more freedom about the types of message objects that can be passed.
