### PR TITLE
Some ideas

### DIFF
--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -48,9 +48,9 @@
  may be best to clear the contents of the message after recognizing the command. The
  -clearMessageContentsForIdentifier: method is provided for this purpose.
  
- A good wormhole includes wormhole aliens who listen for message changes. This class supports 
+ A good wormhole includes wormhole aliens who listen for message changes. This class supports
  CFNotificationCenter Darwin Notifications, which act as a bridge between the containing app and the
- extension. When a message is passed with an identifier, a notification is fired to the Darwin 
+ extension. When a message is passed with an identifier, a notification is fired to the Darwin
  Notification Center with the given identifier. If you have indicated your interest in the message
  by using the -listenForMessageWithIdentifier:completion: method then your completion block will be
  called when this notification is received, and the contents of the message will be unarchived and
@@ -73,8 +73,9 @@
  @param identifier An application group identifier
  @param directory An optional directory to read/write messages
  */
+
 - (instancetype)initWithApplicationGroupIdentifier:(NSString *)identifier
-                                 optionalDirectory:(NSString *)directory;
+                                 optionalDirectory:(NSString *)directory NS_DESIGNATED_INITIALIZER;
 
 /**
  This method passes a message object associated with a given identifier. This is the primary means
@@ -89,7 +90,7 @@
  @param messageobject The message object to be passed
  @param identifier The identifier for the message
  */
-- (void)passMessageObject:(id)messageObject
+- (void)passMessageObject:(id <NSCoding> )messageObject
                identifier:(NSString *)identifier;
 
 /**

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -38,9 +38,14 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
 
 @implementation MMWormhole
 
-- (id)init {    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-designated-initializers"
+
+- (id)init {
     return nil;
 }
+
+#pragma clang diagnostic pop
 
 - (instancetype)initWithApplicationGroupIdentifier:(NSString *)identifier
                                  optionalDirectory:(NSString *)directory {

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -50,6 +50,12 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
 - (instancetype)initWithApplicationGroupIdentifier:(NSString *)identifier
                                  optionalDirectory:(NSString *)directory {
     if ((self = [super init])) {
+        
+        if (NO == [[NSFileManager defaultManager] respondsToSelector:@selector(containerURLForSecurityApplicationGroupIdentifier:)]) {
+            //Protect the user of a crash because of iOSVersion < iOS7
+            return nil;
+        }
+        
         _applicationGroupIdentifier = [identifier copy];
         _directory = [directory copy];
         _fileManager = [[NSFileManager alloc] init];

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -203,7 +203,7 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
 
 #pragma mark - Public Interface Methods
 
-- (void)passMessageObject:(id)messageObject identifier:(NSString *)identifier {
+- (void)passMessageObject:(id <NSCoding>)messageObject identifier:(NSString *)identifier {
     [self writeMessageObject:messageObject toFileWithIdentifier:identifier];
 }
 


### PR DESCRIPTION
- I add some comments to clarify the used mechanism, it's interesting to declare in the interface the protocol that you need to be conform to,
- i fix a little warning on the crazy init method, 
- a "light" support for older iOS version to be able to use manage this pod version in the project podfile (actually, i'm using it on the Universal App with 2 Widgets and a AppleWatch extension, with target OS version iOS6). 

Of course, the Worm is not enable because SDK methods are not available.