### PR TITLE
Exposes darwin notification sending in public header

### DIFF
--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -139,5 +139,5 @@
  */
 - (void)stopListeningForMessageWithIdentifier:(NSString *)identifier;
 
-- (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier;
++ (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier;
 @end

--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -139,4 +139,5 @@
  */
 - (void)stopListeningForMessageWithIdentifier:(NSString *)identifier;
 
+- (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier;
 @end

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -141,6 +141,10 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
 #pragma mark - Private Notification Methods
 
 - (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier {
+    [[self class] sendNotificationForMessageWithIdentifier:identifier];
+}
+
++ (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier  {
     CFNotificationCenterRef const center = CFNotificationCenterGetDarwinNotifyCenter();
     CFDictionaryRef const userInfo = NULL;
     BOOL const deliverImmediately = YES;

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -159,7 +159,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
     [[self class] sendNotificationForMessageWithIdentifier:identifier];
 }
 
-+ (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier  {
++ (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier {
     CFNotificationCenterRef const center = CFNotificationCenterGetDarwinNotifyCenter();
     CFDictionaryRef const userInfo = NULL;
     BOOL const deliverImmediately = YES;


### PR DESCRIPTION
We wanted to send a notification without data. This PR simply exposes the darwin method in the public header. Also, because the instance method made no references to the state I moved it to a class method. To minimize the changes, I kept the internal instance method. Let me know if this is helpful.  