### PR TITLE
Allows to pass messages without object

### DIFF
--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -87,7 +87,8 @@
  listener for a "finished changing" message to let the other side know it's safe to read the 
  contents of your message.
  
- @param messageobject The message object to be passed
+ @param messageobject The message object to be passed. 
+                      This object may be nil. In this case only a notification is posted.
  @param identifier The identifier for the message
  */
 - (void)passMessageObject:(id <NSCoding>)messageObject

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -118,18 +118,21 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
         return;
     }
     
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:messageObject];
-    NSString *filePath = [self filePathForIdentifier:identifier];
-    
-    if (data == nil || filePath == nil) {
-        return;
+    if (messageObject) {
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:messageObject];
+        NSString *filePath = [self filePathForIdentifier:identifier];
+        
+        if (data == nil || filePath == nil) {
+            return;
+        }
+        
+        BOOL success = [data writeToFile:filePath atomically:YES];
+        if (!success) {
+            return;
+        }
     }
     
-    BOOL success = [data writeToFile:filePath atomically:YES];
-    
-    if (success) {
-        [self sendNotificationForMessageWithIdentifier:identifier];
-    }
+    [self sendNotificationForMessageWithIdentifier:identifier];
 }
 
 - (id)messageObjectFromFileWithIdentifier:(NSString *)identifier {

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -127,6 +127,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
         }
         
         BOOL success = [data writeToFile:filePath atomically:YES];
+        
         if (!success) {
             return;
         }


### PR DESCRIPTION
This is an alternative to #17 allowing the sending of darwin notifications only by passing a nil message object.

Closes #17