### PR TITLE
Fixed #31 - wormhole does not work in iOS 8.3 with locked phone

### DIFF
--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -63,6 +63,13 @@
  should use it's own set of identifiers to associate with it's messages back to the application.
  Passing messages to the same identifier from two locations should be done only at your own risk.
  */
+
+typedef NS_ENUM(NSInteger, MMWormholeStoreType) {
+	MMWormholeStoreTypeFile,
+	MMWormholeStoreTypeUserDefaults
+};
+
+
 @interface MMWormhole : NSObject
 
 /**
@@ -70,12 +77,30 @@
  be used to contain passed messages. It is also recommended that you include a directory name for
  messages to be read and written, but this parameter is optional.
  
+ You can also pass custom store option and choose which one to use
+ 
+ @param identifier An application group identifier
+ @param storeType A MMWormholeStoreType enum value that defines
+ @param directory An optional directory to read/write messages
+ */
+
+- (instancetype)initWithApplicationGroupIdentifier:(NSString *)identifier
+										 storeType:(MMWormholeStoreType)storeType
+								 optionalDirectory:(NSString *)directory NS_DESIGNATED_INITIALIZER;
+
+/**
+ This method must be called with an application group identifier that will
+ be used to contain passed messages. It is also recommended that you include a directory name for
+ messages to be read and written, but this parameter is optional.
+ 
+ Uses MMWormholeStoreTypeFile as storage.
+ 
  @param identifier An application group identifier
  @param directory An optional directory to read/write messages
  */
 
 - (instancetype)initWithApplicationGroupIdentifier:(NSString *)identifier
-                                 optionalDirectory:(NSString *)directory NS_DESIGNATED_INITIALIZER;
+                                 optionalDirectory:(NSString *)directory;
 
 /**
  This method passes a message object associated with a given identifier. This is the primary means


### PR DESCRIPTION
Quick update to fix this issue. Adds storeType option to use either shared files (default, it's how MMWormhole works now) and also shared NSUserDefaults in the app group container.

Using defaults seems to work even with the locked iPhone. I will test this a bit more, but it's promising so far.