### PR TITLE
Using new nullability annonations to tell Swift messages might be nil.

### DIFF
--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -23,6 +23,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  This class creates a wormhole between a containing iOS application and an extension. The wormhole
  is meant to be used to pass data or commands back and forth between the two locations. The effect
@@ -75,7 +77,7 @@
  */
 
 - (instancetype)initWithApplicationGroupIdentifier:(NSString *)identifier
-                                 optionalDirectory:(NSString *)directory NS_DESIGNATED_INITIALIZER;
+                                 optionalDirectory:(nullable NSString *)directory NS_DESIGNATED_INITIALIZER;
 
 /**
  This method passes a message object associated with a given identifier. This is the primary means
@@ -91,22 +93,22 @@
                       This object may be nil. In this case only a notification is posted.
  @param identifier The identifier for the message
  */
-- (void)passMessageObject:(id <NSCoding>)messageObject
-               identifier:(NSString *)identifier;
+- (void)passMessageObject:(nullable id <NSCoding>)messageObject
+			   identifier:(nullable NSString *)identifier;
 
 /**
  This method returns the value of a message with a specific identifier as an object.
  
  @param identifier The identifier for the message
  */
-- (id)messageWithIdentifier:(NSString *)identifier;
+- (nullable id)messageWithIdentifier:(nullable NSString *)identifier;
 
 /**
  This method clears the contents of a specific message with a given identifier.
  
  @param identifier The identifier for the message
  */
-- (void)clearMessageContentsForIdentifier:(NSString *)identifier;
+- (void)clearMessageContentsForIdentifier:(nullable NSString *)identifier;
 
 /**
  This method clears the contents of your optional message directory to give you a clean state.
@@ -128,8 +130,8 @@
  @param listener A listener block called with the messageObject parameter when a notification
  is observed.
  */
-- (void)listenForMessageWithIdentifier:(NSString *)identifier
-                              listener:(void (^)(id messageObject))listener;
+- (void)listenForMessageWithIdentifier:(nullable NSString *)identifier
+                              listener:(nullable void (^)(__nullable id messageObject))listener;
 
 /**
  This method stops listening for change notifications for a given message identifier.
@@ -139,6 +141,8 @@
  
  @param identifier The identifier for the message
  */
-- (void)stopListeningForMessageWithIdentifier:(NSString *)identifier;
+- (void)stopListeningForMessageWithIdentifier:(nullable NSString *)identifier;
+
+NS_ASSUME_NONNULL_END
 
 @end

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -29,12 +29,14 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationName";
 
 @interface MMWormhole ()
 
 @property (nonatomic, copy) NSString *applicationGroupIdentifier;
-@property (nonatomic, copy) NSString *directory;
+@property (nonatomic, nullable, copy) NSString *directory;
 @property (nonatomic, strong) NSFileManager *fileManager;
 @property (nonatomic, strong) NSMutableDictionary *listenerBlocks;
 
@@ -52,7 +54,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
 #pragma clang diagnostic pop
 
 - (instancetype)initWithApplicationGroupIdentifier:(NSString *)identifier
-                                 optionalDirectory:(NSString *)directory {
+                                 optionalDirectory:(nullable NSString *)directory {
     if ((self = [super init])) {
         
         if (NO == [[NSFileManager defaultManager] respondsToSelector:@selector(containerURLForSecurityApplicationGroupIdentifier:)]) {
@@ -101,7 +103,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
     return directoryPath;
 }
 
-- (NSString *)filePathForIdentifier:(NSString *)identifier {
+- (NSString *)filePathForIdentifier:(nullable NSString *)identifier {
     if (identifier == nil || identifier.length == 0) {
         return nil;
     }
@@ -113,7 +115,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
     return filePath;
 }
 
-- (void)writeMessageObject:(id)messageObject toFileWithIdentifier:(NSString *)identifier {
+- (void)writeMessageObject:(nullable id)messageObject toFileWithIdentifier:(NSString *)identifier {
     if (identifier == nil) {
         return;
     }
@@ -136,7 +138,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
     [self sendNotificationForMessageWithIdentifier:identifier];
 }
 
-- (id)messageObjectFromFileWithIdentifier:(NSString *)identifier {
+- (id)messageObjectFromFileWithIdentifier:(nullable NSString *)identifier {
     if (identifier == nil) {
         return nil;
     }
@@ -152,14 +154,14 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
     return messageObject;
 }
 
-- (void)deleteFileForIdentifier:(NSString *)identifier {
+- (void)deleteFileForIdentifier:(nullable NSString *)identifier {
     [self.fileManager removeItemAtPath:[self filePathForIdentifier:identifier] error:NULL];
 }
 
 
 #pragma mark - Private Notification Methods
 
-- (void)sendNotificationForMessageWithIdentifier:(NSString *)identifier {
+- (void)sendNotificationForMessageWithIdentifier:(nullable NSString *)identifier {
     CFNotificationCenterRef const center = CFNotificationCenterGetDarwinNotifyCenter();
     CFDictionaryRef const userInfo = NULL;
     BOOL const deliverImmediately = YES;
@@ -167,7 +169,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
     CFNotificationCenterPostNotification(center, str, NULL, userInfo, deliverImmediately);
 }
 
-- (void)registerForNotificationsWithIdentifier:(NSString *)identifier {
+- (void)registerForNotificationsWithIdentifier:(nullable NSString *)identifier {
     CFNotificationCenterRef const center = CFNotificationCenterGetDarwinNotifyCenter();
     CFStringRef str = (__bridge CFStringRef)identifier;
     CFNotificationCenterAddObserver(center,
@@ -178,7 +180,7 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
                                     CFNotificationSuspensionBehaviorDeliverImmediately);
 }
 
-- (void)unregisterForNotificationsWithIdentifier:(NSString *)identifier {
+- (void)unregisterForNotificationsWithIdentifier:(nullable NSString *)identifier {
     CFNotificationCenterRef const center = CFNotificationCenterGetDarwinNotifyCenter();
     CFStringRef str = (__bridge CFStringRef)identifier;
     CFNotificationCenterRemoveObserver(center,
@@ -222,18 +224,18 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
 
 #pragma mark - Public Interface Methods
 
-- (void)passMessageObject:(id <NSCoding>)messageObject identifier:(NSString *)identifier {
+- (void)passMessageObject:(nullable id <NSCoding>)messageObject identifier:(nullable NSString *)identifier {
     [self writeMessageObject:messageObject toFileWithIdentifier:identifier];
 }
 
 
-- (id)messageWithIdentifier:(NSString *)identifier {
+- (nullable id)messageWithIdentifier:(nullable NSString *)identifier {
     id messageObject = [self messageObjectFromFileWithIdentifier:identifier];
     
     return messageObject;
 }
 
-- (void)clearMessageContentsForIdentifier:(NSString *)identifier {
+- (void)clearMessageContentsForIdentifier:(nullable NSString *)identifier {
     [self deleteFileForIdentifier:identifier];
 }
 
@@ -251,15 +253,15 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
     }
 }
 
-- (void)listenForMessageWithIdentifier:(NSString *)identifier
-                              listener:(void (^)(id messageObject))listener {
+- (void)listenForMessageWithIdentifier:(nullable NSString *)identifier
+                              listener:(nullable void (^)(__nullable id messageObject))listener {
     if (identifier != nil) {
         [self.listenerBlocks setValue:listener forKey:identifier];
         [self registerForNotificationsWithIdentifier:identifier];
     }
 }
 
-- (void)stopListeningForMessageWithIdentifier:(NSString *)identifier {
+- (void)stopListeningForMessageWithIdentifier:(nullable NSString *)identifier {
     if (identifier != nil) {
         [self.listenerBlocks setValue:nil forKey:identifier];
         [self unregisterForNotificationsWithIdentifier:identifier];
@@ -267,3 +269,5 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
 }
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
It is possible to get a race condition where a message is removed before the listener block is called and when that happens listener is called with a nil message but the Swift prototypes imply that won't occur. Here's an easy way to see the problem from anything using MMWormhole. (Easiest to run this test on a simulator, since you have to manipulate the file system.)  I should mention that this is an artificial test, but I believe this race condition can actually happen in practice, this is just an easy way to reproduce it.

Set a breakpoint at MMWormhole.m line 204. When you hit the breakpoint go delete the message file from the wormhole folder. Step through the code until at line 211 you'll see

	id messageObject = [self messageObjectFromFileWithIdentifier:identifier];
     
and messageObject will be set to nil.

However, the Swift prototype for listenForMesageWithIdentifier is generated like this:

	    func listenForMessageWithIdentifier(identifier: String!, listener: ((AnyObject!) -> Void)!)

so if you have a handler in Swift like this:

	wormhole.listenForMessageWithIdentifier(appToWidgetUpdatedKey) { (message) -> Void in
			processUpdatedWormholeMessage(message)
	}

you'll get an error message stating:

	unexpectedly found nil while unwrapping an Optional value

and the code will crash.

It's better to write the handler like this, which compiles against the old code:

		wormhole.listenForMessageWithIdentifier(appToWidgetUpdatedKey) { (message) -> Void in
			if let message: AnyObject = message {
				processUpdatedWormholeMessage(message)
			}
		}

which won't crash, but the [nullability annotations](https://developer.apple.com/swift/blog/?id=25) can prevent the former code from compiling. This pull request applies those annotations.
