### PR TITLE
Listener block called multiple times for multiple instances

### DIFF
--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -65,10 +65,11 @@ static NSString * const MMWormholeNotificationName = @"MMWormholeNotificationNam
         _fileManager = [[NSFileManager alloc] init];
         _listenerBlocks = [NSMutableDictionary dictionary];
         
+        // Only respects notification coming from self.
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(didReceiveMessageNotification:)
                                                      name:MMWormholeNotificationName
-                                                   object:nil];
+                                                   object:self];
     }
 
     return self;
@@ -193,8 +194,9 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
                                void const * object,
                                CFDictionaryRef userInfo) {
     NSString *identifier = (__bridge NSString *)name;
+    NSObject *sender = (__bridge NSObject *)(observer);
     [[NSNotificationCenter defaultCenter] postNotificationName:MMWormholeNotificationName
-                                                        object:nil
+                                                        object:sender
                                                       userInfo:@{@"identifier" : identifier}];
 }
 


### PR DESCRIPTION
Fixed issue where multiple MMWormhole instances would get their listener blocks called multiple times.

Sample:

```
//  AppleWatch's FileA.swift 

private var wormholeA : MMWormhole = MMWormhole(....)  // new instance

func awakeWithContext(context: AnyObject?) {
	super.awakeWithContext(context)
	self.wormholeA.listenForMessageWithIdentifier( "MYID" , listener : { (object) -> Void in
		println("FileA called")
	})
}

//  AppleWatch's FileB.swift

private var wormholeB : MMWormhole = MMWormhole(....)   // new instance

func awakeWithContext(context: AnyObject?) {
	super.awakeWithContext(context)
	self.wormholeB.listenForMessageWithIdentifier( "MYID" , listener : { (object) -> Void in
		println("FileB called")
	})
}

// Main Application AppDelegate.swift

let wormholeC = MMWormhole(...)
wormholeC.passMessageObject( "" , identifier : "MYID" )

```

This results to:
FileA called
FileB called   // excess call
FileA called    // excess call
FileB called    


Here's what's happened:

1. wormholeC invokes passMessageObject:identifier:,  eventually calls sendNotificationForMessageWithIdentifier:
2. wormholeA wormholeNotificationCallback is triggered, and post notification MMWormholeNotificationName.
3.  wormholeA.didReceiveMessageNotification and wormholeB.didReceiveMessageNotification  are both triggered since it does not filter where the notification's coming from.  This results to the first "FileA called" and "FileB called"
4. wormholeB wormholeNotificationCallback is triggered, and post notification MMWormholeNotificationName.
5.  wormholeA.didReceiveMessageNotification and wormholeB.didReceiveMessageNotification  are triggered again.  This results to the second "FileA called" and "FileB called"



The issue's number (3) and (5) above.   For each  wormhole instance's wormholeNotificationCallback called, each should only trigger its own  didReceiveMessageNotification.


The fix's to ensure  registration and posting of MMWormholeNotificationName implements "object" filtering.


