### PR TITLE
Added context information for message listener callback

### DIFF
--- a/Example/MMWormhole/MMWormhole WatchKit Extension/InterfaceController.m
+++ b/Example/MMWormhole/MMWormhole WatchKit Extension/InterfaceController.m
@@ -42,7 +42,7 @@
     // Listen for changes to the selection message. The selection message contains a string value
     // identified by the selectionString key. Note that the type of the key is included in the
     // name of the key.
-    [self.wormhole listenForMessageWithIdentifier:@"selection" listener:^(id messageObject) {
+    [self.wormhole listenForMessageWithIdentifier:@"selection" listener:^(id messageObject, NSString* identifier) {
         NSString *string = [messageObject valueForKey:@"selectionString"];
         
         if (string != nil) {

--- a/Example/MMWormhole/MMWormhole/ViewController.m
+++ b/Example/MMWormhole/MMWormhole/ViewController.m
@@ -35,7 +35,7 @@
     self.numberLabel.text = [number stringValue];
     
     // Become a listener for changes to the wormhole for the button message
-    [self.wormhole listenForMessageWithIdentifier:@"button" listener:^(id messageObject) {
+    [self.wormhole listenForMessageWithIdentifier:@"button" listener:^(id messageObject, NSString* identifier) {
         // The number is identified with the buttonNumber key in the message object
         NSNumber *number = [messageObject valueForKey:@"buttonNumber"];
         self.numberLabel.text = [number stringValue];

--- a/Example/MMWormhole/MMWormholeTests/MMWormholeTests.m
+++ b/Example/MMWormhole/MMWormholeTests/MMWormholeTests.m
@@ -163,7 +163,7 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Listener should hear something"];
     
-    [wormhole listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject) {
+    [wormhole listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject, NSString* identifier) {
         XCTAssertNotNil(messageObject, @"Valid message object should not be nil.");
         
         [expectation fulfill];
@@ -187,7 +187,7 @@
     MMWormhole *wormhole1 = [[MMWormhole alloc] initWithApplicationGroupIdentifier:ApplicationGroupIdentifier
                                                                 optionalDirectory:@"testDirectory"];
     
-    [wormhole1 listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject) {
+    [wormhole1 listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject, NSString* identifier) {
         wormhole1ListenerCounter++;
     }];
     
@@ -196,7 +196,7 @@
     MMWormhole *wormhole2 = [[MMWormhole alloc] initWithApplicationGroupIdentifier:ApplicationGroupIdentifier
                                                                  optionalDirectory:@"testDirectory"];
     
-    [wormhole2 listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject) {
+    [wormhole2 listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject, NSString* identifier) {
         wormhole2ListenerCounter++;
     }];
     
@@ -219,7 +219,7 @@
     MMWormhole *wormhole1 = [[MMWormhole alloc] initWithApplicationGroupIdentifier:ApplicationGroupIdentifier
                                                                  optionalDirectory:@"testDirectory"];
     
-    [wormhole1 listenForMessageWithIdentifier:@"testIdentifierWormhole1" listener:^(id messageObject) {
+    [wormhole1 listenForMessageWithIdentifier:@"testIdentifierWormhole1" listener:^(id messageObject, NSString* identifier) {
         wormhole1ListenerCounter++;
         [expectation fulfill];
     }];
@@ -229,7 +229,7 @@
     MMWormhole *wormhole2 = [[MMWormhole alloc] initWithApplicationGroupIdentifier:ApplicationGroupIdentifier
                                                                  optionalDirectory:@"testDirectory"];
     
-    [wormhole2 listenForMessageWithIdentifier:@"testIdentifierWormhole2" listener:^(id messageObject) {
+    [wormhole2 listenForMessageWithIdentifier:@"testIdentifierWormhole2" listener:^(id messageObject, NSString* identifier) {
         wormhole2ListenerCounter++;
     }];
     
@@ -248,7 +248,7 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Listener should hear something"];
     
-    [wormhole listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject) {
+    [wormhole listenForMessageWithIdentifier:@"testIdentifier" listener:^(id messageObject, NSString* identifier) {
         XCTAssertNotNil(messageObject, @"Valid message object should not be nil.");
         
         [expectation fulfill];

--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -31,6 +31,8 @@ FOUNDATION_EXPORT double MMWormholeVersionNumber;
 //! Project version string for MMWormhole.
 FOUNDATION_EXPORT const unsigned char MMWormholeVersionString[];
 
+typedef void(^MMWormholeListenerCallback)(__nullable id messageObject, NSString* identifier);
+
 /**
  This class creates a wormhole between a containing iOS application and an extension. The wormhole
  is meant to be used to pass data or commands back and forth between the two locations. The effect
@@ -137,7 +139,7 @@ FOUNDATION_EXPORT const unsigned char MMWormholeVersionString[];
  is observed.
  */
 - (void)listenForMessageWithIdentifier:(nullable NSString *)identifier
-                              listener:(nullable void (^)(__nullable id messageObject))listener;
+                              listener:(nullable MMWormholeListenerCallback)listener;
 
 /**
  This method stops listening for change notifications for a given message identifier.

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -225,12 +225,12 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
     NSString *identifier = [userInfo valueForKey:@"identifier"];
     
     if (identifier != nil) {
-        MessageListenerBlock listenerBlock = [self listenerBlockForIdentifier:identifier];
+        MMWormholeListenerCallback listenerBlock = [self listenerBlockForIdentifier:identifier];
 
         if (listenerBlock) {
             id messageObject = [self messageObjectFromFileWithIdentifier:identifier];
 
-            listenerBlock(messageObject);
+            listenerBlock(messageObject, identifier);
         }
     }
 }
@@ -272,7 +272,7 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
 }
 
 - (void)listenForMessageWithIdentifier:(nullable NSString *)identifier
-                              listener:(nullable void (^)(__nullable id messageObject))listener {
+                              listener:(nullable MMWormholeListenerCallback)listener {
     if (identifier != nil) {
         [self.listenerBlocks setValue:listener forKey:identifier];
         [self registerForNotificationsWithIdentifier:identifier];


### PR DESCRIPTION
Added additional context information, such as 'NSString* identifier' for message listener