### PR TITLE
Add MMWormHoleFileTransiting.h, MMwormholeCoordinatedFileTransiting.h to umbrella header

### DIFF
--- a/MMWormhole/MMWormhole.xcodeproj/project.pbxproj
+++ b/MMWormhole/MMWormhole.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		9B44A51C1B00572E00C9969A /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B44A4801B0055F500C9969A /* MMWormhole.m */; };
 		9B44A51D1B00572E00C9969A /* MMWormhole.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B44A47F1B0055F500C9969A /* MMWormhole.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B44A51E1B00572E00C9969A /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B44A4801B0055F500C9969A /* MMWormhole.m */; };
+		AE46A9511B7E58B70032B6AB /* MMWormholeTransiting.h in Headers */ = {isa = PBXBuildFile; fileRef = AE46A9501B7E58B70032B6AB /* MMWormholeTransiting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AE46A9521B7E58B70032B6AB /* MMWormholeTransiting.h in Headers */ = {isa = PBXBuildFile; fileRef = AE46A9501B7E58B70032B6AB /* MMWormholeTransiting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +33,7 @@
 		9B44A4801B0055F500C9969A /* MMWormhole.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMWormhole.m; sourceTree = "<group>"; };
 		9B44A4C61B00570E00C9969A /* MMWormhole.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MMWormhole.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B44A5021B00571F00C9969A /* MMWormhole.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MMWormhole.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE46A9501B7E58B70032B6AB /* MMWormholeTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMWormholeTransiting.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +93,7 @@
 			children = (
 				9B44A47F1B0055F500C9969A /* MMWormhole.h */,
 				9B44A4801B0055F500C9969A /* MMWormhole.m */,
+				AE46A9501B7E58B70032B6AB /* MMWormholeTransiting.h */,
 				55030BD61B165D8F005EFC19 /* MMWormholeCoordinatedFileTransiting.h */,
 				55030BD71B165D8F005EFC19 /* MMWormholeCoordinatedFileTransiting.m */,
 				55030BD81B165D8F005EFC19 /* MMWormholeFileTransiting.h */,
@@ -108,6 +112,7 @@
 			files = (
 				55030BDE1B165D8F005EFC19 /* MMWormholeFileTransiting.h in Headers */,
 				9B44A51B1B00572E00C9969A /* MMWormhole.h in Headers */,
+				AE46A9511B7E58B70032B6AB /* MMWormholeTransiting.h in Headers */,
 				55030BDA1B165D8F005EFC19 /* MMWormholeCoordinatedFileTransiting.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -118,6 +123,7 @@
 			files = (
 				55030BDF1B165D8F005EFC19 /* MMWormholeFileTransiting.h in Headers */,
 				9B44A51D1B00572E00C9969A /* MMWormhole.h in Headers */,
+				AE46A9521B7E58B70032B6AB /* MMWormholeTransiting.h in Headers */,
 				55030BDB1B165D8F005EFC19 /* MMWormholeCoordinatedFileTransiting.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -241,6 +247,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -288,6 +295,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -328,7 +336,6 @@
 		9B44A4DA1B00570F00C9969A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -349,7 +356,6 @@
 		9B44A4DB1B00570F00C9969A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -22,6 +22,9 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import "MMWormholeTransiting.h"
+#import "MMWormHoleCoordinatedFileTransiting.h"
+#import "MMWormholeFileTransiting.h"
 
 @protocol MMWormholeTransiting;
 
@@ -166,52 +169,6 @@ FOUNDATION_EXPORT const unsigned char MMWormholeVersionString[];
  @param identifier The identifier for the message
  */
 - (void)stopListeningForMessageWithIdentifier:(nullable NSString *)identifier;
-
-@end
-
-
-/**
- This protocol defines the public interface for classes wishing to support the transiting of data
- between two sides of the wormhole. Transiting is defined as passage between two points, and in this
- case it involves both the reading and writing of messages as well as the deletion of message
- contents.
- */
-@protocol MMWormholeTransiting <NSObject>
-
-/**
- This method is responsible for writing a given message object in a persisted format for a given
- identifier. The method should return YES if the message was successfully saved. The message object 
- may be nil, in which case YES should also be returned. Returning YES from this method results in a 
- notification being fired which will trigger the corresponding listener block for the given 
- identifier.
- 
- @param messageObject The message object to be passed.
- This object may be nil. In this the method should return YES.
- @param identifier The identifier for the message
- @return YES indicating that a notification should be sent and NO otherwise
- */
-- (BOOL)writeMessageObject:(nullable id<NSCoding>)messageObject forIdentifier:(NSString *)identifier;
-
-/**
- This method is responsible for reading and returning the contents of a given message. It should
- understand the structure of messages saved by the implementation of the above writeMessageObject
- method and be able to read those messages and return their contents.
- 
- @param identifier The identifier for the message
-*/
-- (nullable id<NSCoding>)messageObjectForIdentifier:(nullable NSString *)identifier;
-
-/**
- This method should clear the persisted contents of a specific message with a given identifier.
- 
- @param identifier The identifier for the message
- */
-- (void)deleteContentForIdentifier:(nullable NSString *)identifier;
-
-/**
- This method should clear the contents of all messages passed to the wormhole.
- */
-- (void)deleteContentForAllMessages;
 
 @end
 

--- a/Source/MMWormholeFileTransiting.h
+++ b/Source/MMWormholeFileTransiting.h
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "MMWormhole.h"
+#import <Foundation/Foundation.h>
+#import "MMWormholeTransiting.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/MMWormholeFileTransiting.m
+++ b/Source/MMWormholeFileTransiting.m
@@ -21,8 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-
+#import "MMWormhole.h"
 #import "MMWormholeFileTransiting.h"
 
 @interface MMWormholeFileTransiting ()

--- a/Source/MMWormholeTransiting.h
+++ b/Source/MMWormholeTransiting.h
@@ -1,0 +1,73 @@
+//
+//  MMWormholeTransiting.h
+//
+// Copyright (c) 2014 Mutual Mobile (http://www.mutualmobile.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ This protocol defines the public interface for classes wishing to support the transiting of data
+ between two sides of the wormhole. Transiting is defined as passage between two points, and in this
+ case it involves both the reading and writing of messages as well as the deletion of message
+ contents.
+ */
+@protocol MMWormholeTransiting <NSObject>
+
+/**
+ This method is responsible for writing a given message object in a persisted format for a given
+ identifier. The method should return YES if the message was successfully saved. The message object
+ may be nil, in which case YES should also be returned. Returning YES from this method results in a
+ notification being fired which will trigger the corresponding listener block for the given
+ identifier.
+
+ @param messageObject The message object to be passed.
+ This object may be nil. In this the method should return YES.
+ @param identifier The identifier for the message
+ @return YES indicating that a notification should be sent and NO otherwise
+ */
+- (BOOL)writeMessageObject:(nullable id<NSCoding>)messageObject forIdentifier:(NSString *)identifier;
+
+/**
+ This method is responsible for reading and returning the contents of a given message. It should
+ understand the structure of messages saved by the implementation of the above writeMessageObject
+ method and be able to read those messages and return their contents.
+
+ @param identifier The identifier for the message
+ */
+- (nullable id<NSCoding>)messageObjectForIdentifier:(nullable NSString *)identifier;
+
+/**
+ This method should clear the persisted contents of a specific message with a given identifier.
+
+ @param identifier The identifier for the message
+ */
+- (void)deleteContentForIdentifier:(nullable NSString *)identifier;
+
+/**
+ This method should clear the contents of all messages passed to the wormhole.
+ */
+- (void)deleteContentForAllMessages;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Split out MMWormholeTransiting protocol definition to its own file, also included in the umbrella header

This removes a build warning that the public headers are not all included in the umbrella header, which causes an error when using the -wError compiler flag.