### PR TITLE
Explicitly setting data protection attributes on files being written so they can be read by a WatchKit extension even when the paired phone is locked

### DIFF
--- a/Source/MMWormholeFileTransiting.m
+++ b/Source/MMWormholeFileTransiting.m
@@ -109,10 +109,15 @@
         if (data == nil || filePath == nil) {
             return NO;
         }
-        
-        BOOL success = [data writeToFile:filePath atomically:YES];
-        
+
+		NSError *error = nil;
+        BOOL success = [data
+			writeToFile:filePath
+			options:NSDataWritingAtomic | NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication
+			error:&error
+		];
         if (!success) {
+			NSLog(@"%@: could not save a file with message '%@': %@", self.class, identifier, error);
             return NO;
         }
     }


### PR DESCRIPTION
We use complete data protection in our app by default, so files written by MMWormhole cannot be read when the device is locked (happens on iOS 8.4 and WatchOS 1.0.1). Setting the data protection attribute of the files being written to 'CompleteUntilFirstUserAuthentication' resolves this for us.
