### PR TITLE
Run xcode 10 migration wizard

### DIFF
--- a/MMWormhole/MMWormhole.xcodeproj/project.pbxproj
+++ b/MMWormhole/MMWormhole.xcodeproj/project.pbxproj
@@ -16,13 +16,13 @@
 		55030BE01B165D8F005EFC19 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55030BD91B165D8F005EFC19 /* MMWormholeFileTransiting.m */; };
 		55030BE11B165D8F005EFC19 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55030BD91B165D8F005EFC19 /* MMWormholeFileTransiting.m */; };
 		55AB6EF31BA77D8F003908DC /* MMWormholeSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AB6EEA1BA77D8F003908DC /* MMWormholeSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55AB6EF51BA77D8F003908DC /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EEB1BA77D8F003908DC /* MMWormholeSession.m */; settings = {ASSET_TAGS = (); }; };
+		55AB6EF51BA77D8F003908DC /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EEB1BA77D8F003908DC /* MMWormholeSession.m */; };
 		55AB6EF71BA77D8F003908DC /* MMWormholeSessionContextTransiting.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AB6EEC1BA77D8F003908DC /* MMWormholeSessionContextTransiting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55AB6EF91BA77D8F003908DC /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EED1BA77D8F003908DC /* MMWormholeSessionContextTransiting.m */; settings = {ASSET_TAGS = (); }; };
+		55AB6EF91BA77D8F003908DC /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EED1BA77D8F003908DC /* MMWormholeSessionContextTransiting.m */; };
 		55AB6EFB1BA77D8F003908DC /* MMWormholeSessionFileTransiting.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AB6EEE1BA77D8F003908DC /* MMWormholeSessionFileTransiting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55AB6EFD1BA77D8F003908DC /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EEF1BA77D8F003908DC /* MMWormholeSessionFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
+		55AB6EFD1BA77D8F003908DC /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EEF1BA77D8F003908DC /* MMWormholeSessionFileTransiting.m */; };
 		55AB6EFF1BA77D8F003908DC /* MMWormholeSessionMessageTransiting.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AB6EF01BA77D8F003908DC /* MMWormholeSessionMessageTransiting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55AB6F011BA77D8F003908DC /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EF11BA77D8F003908DC /* MMWormholeSessionMessageTransiting.m */; settings = {ASSET_TAGS = (); }; };
+		55AB6F011BA77D8F003908DC /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AB6EF11BA77D8F003908DC /* MMWormholeSessionMessageTransiting.m */; };
 		55AB6F031BA77D8F003908DC /* MMWormholeTransiting.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AB6EF21BA77D8F003908DC /* MMWormholeTransiting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55AB6F041BA77D8F003908DC /* MMWormholeTransiting.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AB6EF21BA77D8F003908DC /* MMWormholeTransiting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B44A51B1B00572E00C9969A /* MMWormhole.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B44A47F1B0055F500C9969A /* MMWormhole.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -209,7 +209,7 @@
 		9B44A4591B0055C500C9969A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = MMWormhole;
 				TargetAttributes = {
 					9B44A4C51B00570E00C9969A = {
@@ -292,13 +292,23 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -341,13 +351,23 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -378,6 +398,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -401,6 +422,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/MMWormhole/MMWormhole.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MMWormhole/MMWormhole.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MMWormhole/MMWormhole.xcodeproj/xcshareddata/xcschemes/MMWormhole-Mac.xcscheme
+++ b/MMWormhole/MMWormhole.xcodeproj/xcshareddata/xcschemes/MMWormhole-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MMWormhole/MMWormhole.xcodeproj/xcshareddata/xcschemes/MMWormhole-iOS.xcscheme
+++ b/MMWormhole/MMWormhole.xcodeproj/xcshareddata/xcschemes/MMWormhole-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Ran the Xcode 10 migration wizard, no code changes.

We use this project as a submodule off a tag, it would be greatly appreciated if you could merge this a create a new tag from it so we can kill the Xcode warnings. Thanks!