### PR TITLE
Multiple Message Passing Implementation

### DIFF
--- a/Example/MMWormhole/MMWormhole.xcodeproj/project.pbxproj
+++ b/Example/MMWormhole/MMWormhole.xcodeproj/project.pbxproj
@@ -21,34 +21,34 @@
 		2679DC051A33C45200961787 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2679DC041A33C45200961787 /* Interface.storyboard */; };
 		2679DC071A33C45200961787 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2679DC061A33C45200961787 /* Images.xcassets */; };
 		2679DC0A1A33C45200961787 /* MMWormhole WatchKit Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 2679DBEF1A33C45200961787 /* MMWormhole WatchKit Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		26C184D21BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; settings = {ASSET_TAGS = (); }; };
-		26C184D31BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; settings = {ASSET_TAGS = (); }; };
-		26C184D41BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; settings = {ASSET_TAGS = (); }; };
-		26C184D51BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; settings = {ASSET_TAGS = (); }; };
-		26C184D61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184D71BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184D81BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184D91BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184DA1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184DB1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184DC1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184DD1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184DE1BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; settings = {ASSET_TAGS = (); }; };
-		26C184DF1BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E01BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E11BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E21BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E31BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E41BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E51BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E61BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E71BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E81BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184E91BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184EA1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184EB1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184EC1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; settings = {ASSET_TAGS = (); }; };
-		26C184ED1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; settings = {ASSET_TAGS = (); }; };
+		26C184D21BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; };
+		26C184D31BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; };
+		26C184D41BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; };
+		26C184D51BA5DDA5001A8063 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C41BA5DDA5001A8063 /* MMWormhole.m */; };
+		26C184D61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; };
+		26C184D71BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; };
+		26C184D81BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; };
+		26C184D91BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m */; };
+		26C184DA1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; };
+		26C184DB1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; };
+		26C184DC1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; };
+		26C184DD1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184C81BA5DDA5001A8063 /* MMWormholeFileTransiting.m */; };
+		26C184DE1BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; };
+		26C184DF1BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; };
+		26C184E01BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; };
+		26C184E11BA5DDA5001A8063 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CA1BA5DDA5001A8063 /* MMWormholeSession.m */; };
+		26C184E21BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; };
+		26C184E31BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; };
+		26C184E41BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; };
+		26C184E51BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CC1BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m */; };
+		26C184E61BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; };
+		26C184E71BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; };
+		26C184E81BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; };
+		26C184E91BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184CE1BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m */; };
+		26C184EA1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; };
+		26C184EB1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; };
+		26C184EC1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; };
+		26C184ED1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = 26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */; };
 		55030BCD1B163680005EFC19 /* MMWormholeFileTransitingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55030BCC1B163680005EFC19 /* MMWormholeFileTransitingTests.m */; };
 		55030BD51B165857005EFC19 /* MMWormholeCoordinatedFileTransitingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55030BD41B165857005EFC19 /* MMWormholeCoordinatedFileTransitingTests.m */; };
 		55D935F41A38A4F200AD1A1C /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D935F31A38A4F200AD1A1C /* NotificationCenter.framework */; };
@@ -62,6 +62,10 @@
 		55E647011B2659FB006ADC7F /* ExtensionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E647001B2659FB006ADC7F /* ExtensionDelegate.m */; };
 		55E6470C1B2659FB006ADC7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55E6470B1B2659FB006ADC7F /* Assets.xcassets */; };
 		55E647101B2659FB006ADC7F /* watchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 55E646E91B2659FB006ADC7F /* watchOS.app */; };
+		B5217F2E244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = B5217F2C244B2EEA00D811BC /* MMWormholeManifestFileTransiting.m */; };
+		B5217F2F244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = B5217F2C244B2EEA00D811BC /* MMWormholeManifestFileTransiting.m */; };
+		B5217F30244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = B5217F2C244B2EEA00D811BC /* MMWormholeManifestFileTransiting.m */; };
+		B5217F31244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = B5217F2C244B2EEA00D811BC /* MMWormholeManifestFileTransiting.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -209,6 +213,8 @@
 		55E6470B1B2659FB006ADC7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		55E6470D1B2659FB006ADC7F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55E6471C1B265AFA006ADC7F /* watchOS Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "watchOS Extension.entitlements"; sourceTree = "<group>"; };
+		B5217F2C244B2EEA00D811BC /* MMWormholeManifestFileTransiting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeManifestFileTransiting.m; path = ../../../Source/MMWormholeManifestFileTransiting.m; sourceTree = "<group>"; };
+		B5217F2D244B2EEA00D811BC /* MMWormholeManifestFileTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeManifestFileTransiting.h; path = ../../../Source/MMWormholeManifestFileTransiting.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -399,6 +405,8 @@
 				26C184CF1BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.h */,
 				26C184D01BA5DDA5001A8063 /* MMWormholeSessionMessageTransiting.m */,
 				26C184D11BA5DDA5001A8063 /* MMWormholeTransiting.h */,
+				B5217F2D244B2EEA00D811BC /* MMWormholeManifestFileTransiting.h */,
+				B5217F2C244B2EEA00D811BC /* MMWormholeManifestFileTransiting.m */,
 			);
 			name = MMWormhole;
 			sourceTree = "<group>";
@@ -648,6 +656,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -740,6 +749,7 @@
 				26C184DA1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */,
 				26C184E21BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */,
 				2679DBC51A33B7C700961787 /* AppDelegate.m in Sources */,
+				B5217F2E244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */,
 				26C184D61BA5DDA5001A8063 /* MMWormholeCoordinatedFileTransiting.m in Sources */,
 				26C184D21BA5DDA5001A8063 /* MMWormhole.m in Sources */,
 				2679DBC21A33B7C700961787 /* main.m in Sources */,
@@ -768,6 +778,7 @@
 				26C184E31BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */,
 				26C184D31BA5DDA5001A8063 /* MMWormhole.m in Sources */,
 				2679DBF81A33C45200961787 /* InterfaceController.m in Sources */,
+				B5217F2F244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */,
 				26C184DB1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */,
 				26C184E71BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */,
 			);
@@ -783,6 +794,7 @@
 				26C184E41BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */,
 				26C184D41BA5DDA5001A8063 /* MMWormhole.m in Sources */,
 				55D935FA1A38A4F200AD1A1C /* TodayViewController.m in Sources */,
+				B5217F30244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */,
 				26C184DC1BA5DDA5001A8063 /* MMWormholeFileTransiting.m in Sources */,
 				26C184E81BA5DDA5001A8063 /* MMWormholeSessionFileTransiting.m in Sources */,
 			);
@@ -792,6 +804,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5217F31244B2EEB00D811BC /* MMWormholeManifestFileTransiting.m in Sources */,
 				26C184E51BA5DDA5001A8063 /* MMWormholeSessionContextTransiting.m in Sources */,
 				55E647011B2659FB006ADC7F /* ExtensionDelegate.m in Sources */,
 				55E646FE1B2659FB006ADC7F /* InterfaceController.m in Sources */,

--- a/MMWormhole.podspec
+++ b/MMWormhole.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |core|
     core.ios.source_files = 'Source/*.{h,m}'
     core.watchos.source_files = 'Source/*.{h,m}'
-    core.osx.source_files = 'Source/MMWormhole.{h,m}', 'Source/MMWormholeFileTransiting.{h,m}', 'Source/MMWormholeCoordinatedFileTransiting.{h,m}', 'Source/MMWormholeTransiting.h'
+    core.osx.source_files = 'Source/MMWormhole.{h,m}', 'Source/MMWormholeFileTransiting.{h,m}', 'Source/MMWormholeManifestFileTransiting.{h,m}', 'Source/MMWormholeCoordinatedFileTransiting.{h,m}', 'Source/MMWormholeTransiting.h'
   end  
 end

--- a/Source/MMWormhole.h
+++ b/Source/MMWormhole.h
@@ -24,6 +24,7 @@
 #import <Foundation/Foundation.h>
 
 #import "MMWormholeCoordinatedFileTransiting.h"
+#import "MMWormholeManifestFileTransiting.h"
 #import "MMWormholeFileTransiting.h"
 
 #if ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 )
@@ -37,6 +38,7 @@
 typedef NS_ENUM(NSInteger, MMWormholeTransitingType) {
     MMWormholeTransitingTypeFile = 0,
     MMWormholeTransitingTypeCoordinatedFile,
+    MMWormholeTransitingTypeManifestFile,
     MMWormholeTransitingTypeSessionContext,
     MMWormholeTransitingTypeSessionMessage,
     MMWormholeTransitingTypeSessionFile

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -92,6 +92,10 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
                 self.wormholeMessenger = [[MMWormholeCoordinatedFileTransiting alloc] initWithApplicationGroupIdentifier:identifier
                                                                                                        optionalDirectory:directory];
                 break;
+            case MMWormholeTransitingTypeManifestFile:
+                self.wormholeMessenger = [[MMWormholeManifestFileTransiting alloc] initWithApplicationGroupIdentifier:identifier
+                                                                                                       optionalDirectory:directory];
+                break;
             case MMWormholeTransitingTypeSessionContext:
 #if ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 )
                 self.wormholeMessenger = [[MMWormholeSessionContextTransiting alloc] initWithApplicationGroupIdentifier:identifier

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -179,10 +179,21 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
     NSString *identifier = [userInfo valueForKey:@"identifier"];
     
     if (identifier != nil) {
-        id messageObject = [self.wormholeMessenger messageObjectForIdentifier:identifier];
-
-        [self notifyListenerForMessageWithIdentifier:identifier message:messageObject];
+#if ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 )
+        if ([self.wormholeMessenger respondsToSelector:@selector(numberOfMessageItemsforIdentifier:)]) {
+            NSInteger messageCount = [self.wormholeMessenger numberOfMessageItemsforIdentifier:identifier];
+            for (int i = 0; i < messageCount; i++) {
+                [self _sendNotificationForIdentifier:identifier];
+            }
+        }
+#endif
+        [self _sendNotificationForIdentifier:identifier];
     }
+}
+
+- (void)_sendNotificationForIdentifier:(NSString *)identifier {
+    id messageObject = [self.wormholeMessenger messageObjectForIdentifier:identifier];
+    [self notifyListenerForMessageWithIdentifier:identifier message:messageObject];
 }
 
 - (id)listenerBlockForIdentifier:(NSString *)identifier {

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -185,6 +185,7 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
             for (int i = 0; i < messageCount; i++) {
                 [self _sendNotificationForIdentifier:identifier];
             }
+            return;
         }
 #endif
         [self _sendNotificationForIdentifier:identifier];

--- a/Source/MMWormhole.m
+++ b/Source/MMWormhole.m
@@ -179,7 +179,7 @@ void wormholeNotificationCallback(CFNotificationCenterRef center,
     NSString *identifier = [userInfo valueForKey:@"identifier"];
     
     if (identifier != nil) {
-#if ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 )
+#if ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 && !TARGET_OS_SIMULATOR )
         if ([self.wormholeMessenger respondsToSelector:@selector(numberOfMessageItemsforIdentifier:)]) {
             NSInteger messageCount = [self.wormholeMessenger numberOfMessageItemsforIdentifier:identifier];
             for (int i = 0; i < messageCount; i++) {

--- a/Source/MMWormholeManifestFileTransiting.h
+++ b/Source/MMWormholeManifestFileTransiting.h
@@ -1,0 +1,37 @@
+//
+// MMWormholeCoordinatedFileTransiting.h
+//
+// Copyright (c) 2015 Mutual Mobile (http://www.mutualmobile.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MMWormholeFileTransiting.h"
+
+/**
+This class inherits from the default implementation of the MMWormholeTransiting protocol
+and copies the message transiting implementation from MMWormholeCoordinatedFileTransiting.
+ 
+In addition, it utilizes a manifest object (a wrapping NSArray) to store unique object copies, thus enabling
+multiple unique message storage and replay. 
+*/
+@interface MMWormholeManifestFileTransiting : MMWormholeFileTransiting
+
+@property (nonatomic, assign) NSDataWritingOptions additionalFileWritingOptions;
+
+@end

--- a/Source/MMWormholeManifestFileTransiting.m
+++ b/Source/MMWormholeManifestFileTransiting.m
@@ -59,8 +59,6 @@
         return nil;
     }
     
-    //Arguably unsafe as something else could change us on disk
-    //TODO: utilize encrypted container with NSSecureCoding to avoid above
     NSArray *storageArray = [self _arrayForIdentifier:identifier];
     if ([storageArray count] == 0) {
         return nil;
@@ -78,7 +76,6 @@
 #pragma mark - Helper Methods
 
 - (BOOL)_writeArrayToDisk:(NSArray *)array forIdentifier:(NSString *)identifier{
-    //Encode manifest instead of message object
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:array];
     NSString *filePath = [self filePathForIdentifier:identifier];
     NSURL *fileURL = [NSURL fileURLWithPath:filePath];

--- a/Source/MMWormholeManifestFileTransiting.m
+++ b/Source/MMWormholeManifestFileTransiting.m
@@ -54,7 +54,6 @@
     return YES;
 }
 
-
 - (id<NSCoding>)messageObjectForIdentifier:(NSString *)identifier {
     if (identifier == nil) {
         return nil;

--- a/Source/MMWormholeManifestFileTransiting.m
+++ b/Source/MMWormholeManifestFileTransiting.m
@@ -1,0 +1,144 @@
+//
+// MMWormholeCoordinatedFileTransiting.h
+//
+// Copyright (c) 2015 Mutual Mobile (http://www.mutualmobile.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MMWormholeManifestFileTransiting.h"
+
+@implementation MMWormholeManifestFileTransiting
+
+#pragma mark - MMWormholeTransiting Methods
+
+- (BOOL)writeMessageObject:(id<NSCoding>)messageObject forIdentifier:(NSString *)identifier {
+    if (identifier == nil) {
+        return NO;
+    }
+    
+    if (messageObject) {
+        //Insert into manifest
+        NSMutableArray *storageArray = nil;
+        NSArray *potentialOnDiskArray = (NSArray *)[self _arrayForIdentifier:identifier];
+        if (potentialOnDiskArray) {
+            storageArray = [NSMutableArray arrayWithArray:potentialOnDiskArray];
+        } else {
+            storageArray = [[NSMutableArray alloc] init];
+        }
+        [storageArray addObject:messageObject];
+        
+        //Encode manifest instead of message object
+        BOOL success = [self _writeArrayToDisk:storageArray forIdentifier:identifier];
+        
+        if (!success) {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+
+- (id<NSCoding>)messageObjectForIdentifier:(NSString *)identifier {
+    if (identifier == nil) {
+        return nil;
+    }
+    
+    //Arguably unsafe as something else could change us on disk
+    //TODO: utilize encrypted container with NSSecureCoding to avoid above
+    NSArray *storageArray = [self _arrayForIdentifier:identifier];
+    if ([storageArray count] == 0) {
+        return nil;
+    }
+    id messageObject = storageArray[0];
+    NSMutableArray *arrayToWrite = [NSMutableArray arrayWithArray:storageArray];
+    [arrayToWrite removeObjectAtIndex:0];
+    
+    //TODO: What to do if this fails?
+    [self _writeArrayToDisk:arrayToWrite forIdentifier:identifier];
+    
+    return messageObject;
+}
+
+#pragma mark - Helper Methods
+
+- (BOOL)_writeArrayToDisk:(NSArray *)array forIdentifier:(NSString *)identifier{
+    //Encode manifest instead of message object
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:array];
+    NSString *filePath = [self filePathForIdentifier:identifier];
+    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
+    
+    if (data == nil || filePath == nil || fileURL == nil) {
+        return NO;
+    }
+    
+    NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] initWithFilePresenter:nil];
+    NSError *error = nil;
+    __block BOOL success = NO;
+    
+    [fileCoordinator
+     coordinateWritingItemAtURL:fileURL
+     options:0
+     error:&error
+     byAccessor:^(NSURL *newURL) {
+         NSError *writeError = nil;
+         
+         success = [data writeToURL:newURL
+                            options:NSDataWritingAtomic | self.additionalFileWritingOptions
+                              error:&writeError];
+     }];
+    
+    return success;
+}
+
+- (nullable NSArray*)_arrayForIdentifier:(NSString *)identifier{
+    if (identifier == nil) {
+        return nil;
+    }
+    
+    NSString *filePath = [self filePathForIdentifier:identifier];
+    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
+    
+    if (filePath == nil || fileURL == nil) {
+        return nil;
+    }
+    
+    NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] initWithFilePresenter:nil];
+    NSError *error = nil;
+    __block NSData *data = nil;
+    
+    [fileCoordinator
+     coordinateReadingItemAtURL:fileURL
+     options:0
+     error:&error
+     byAccessor:^(NSURL *newURL) {
+         data = [NSData dataWithContentsOfURL:newURL];
+     }];
+    
+    if (data == nil) {
+        return nil;
+    }
+    
+    //Arguably unsafe as something else could change us on disk
+    //TODO: utilize encrypted container with NSSecureCoding to avoid above
+    NSArray *storageArray = (NSArray *)[NSKeyedUnarchiver unarchiveObjectWithData:data];
+    return storageArray;
+}
+
+@end

--- a/Source/MMWormholeManifestFileTransiting.m
+++ b/Source/MMWormholeManifestFileTransiting.m
@@ -36,7 +36,8 @@
         //Insert into manifest
         NSMutableArray *storageArray = nil;
         NSArray *potentialOnDiskArray = (NSArray *)[self _arrayForIdentifier:identifier];
-        if (potentialOnDiskArray) {
+        //Covers edge cases where a crash can occur when changing to using this transit style from other styles
+        if ([potentialOnDiskArray isKindOfClass:[NSArray class]]) {
             storageArray = [NSMutableArray arrayWithArray:potentialOnDiskArray];
         } else {
             storageArray = [[NSMutableArray alloc] init];

--- a/Source/MMWormholeManifestFileTransiting.m
+++ b/Source/MMWormholeManifestFileTransiting.m
@@ -74,6 +74,15 @@
     return messageObject;
 }
 
+
+- (NSInteger)numberOfMessageItemsforIdentifier:(NSString *)identifier {
+    NSArray *array = [self _arrayForIdentifier:identifier];
+    if ([array isKindOfClass:[NSArray class]]) {
+        return array.count;
+    }
+    return 0;
+}
+
 #pragma mark - Helper Methods
 
 - (BOOL)_writeArrayToDisk:(NSArray *)array forIdentifier:(NSString *)identifier{

--- a/Source/MMWormholeTransiting.h
+++ b/Source/MMWormholeTransiting.h
@@ -68,6 +68,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)deleteContentForAllMessages;
 
+@optional
+
+/**
+ This method returns the total number of items on disk we need to dispatch messages for. Used on iOS 13+
+ to enqueue multiple messages for dispatch
+ */
+- (NSInteger)numberOfMessageItemsforIdentifier:(NSString *)identifier;
+
 @end
 
 @protocol MMWormholeTransitingDelegate <NSObject>


### PR DESCRIPTION
Hello folks! Seems like this library is mostly unmaintained but I figured I'd open this PR for posterity sake incase anyone else needs this.

### Issue
The default `MMWormholeFileTransiting` and its subclass `MMWormholeCoordinatedFileTransiting` both have an inherent issue where they support enqueuing multiple messages across the wormhole, BUT every time a message is enqueued, it overwrites the message payload. So, when attempting to transit `N` message payloads across the wormhole (similar to how `NSNotificationCenter` or any other message bus construct works), you get `N` messages but only the latest written payload.

### Solution
This doesn't work for my use case unfortunately, so thus I present `MMWormholeManifestFileTransiting` for your inspection and approval. It utilizes the more modern NSFileCoordinator-based approach from `MMWormholeCoordinatedFileTransiting` but instead of just writing the message to disk and thus overwriting whatever is currently there, it manages a stack (`NSArray`) of messages that need to be sent across the wormhole which are then dispatched FILO style across the wormhole via pushing and popping the stack.

There's a few potential improvements / optimizations to be made here:
- Implement a FIFO queue management in addition to the existing FILO system. For my use case this would change nothing but I could see it being useful if ordering mattered if delivery is delayed (as my use case of sending data from an ActionExtension is)
- Cleanup synchronization between messages on disk and notifications sent to the app. There's potential for drift here if for some reason the CF notification fails to deliver, as then we'll have messages enqueued in the array with no matching notification. The framework could expect the calling code to handle this case as well if that's an expected problem, which in my testing hasn't happened.