### PR TITLE
Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ DerivedData
 .DS_Store
 Example/.DS_Store
 Example/MMWormhole/.DS_Store
+# Swift Package Manager
+.build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##[2.1.0]
+**NEW**
+* Added Swift Package Manager support. (Eli Gutovsky)
+
 ##[2.0.0](https://github.com/mutualmobile/MMWormhole/milestones/2.0.0) (Tuesday, September 15th, 2015)
 **NEW**
 * Added support for the WatchConnectivity framework. (Conrad Stoll)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "MMWormhole",
+    platforms: [
+        .macOS(.v10_13),
+        .iOS(.v11),
+        .watchOS(.v2),
+    ],
+    products: [
+        .library(
+            name: "MMWormhole",
+            targets: ["MMWormhole"]),
+    ],
+    targets: [
+        .target(
+            name: "MMWormhole",
+            path: "Source",
+            publicHeadersPath: "."),
+    ])

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,6 @@ let package = Package(
             path: "Source",
             publicHeadersPath: ".",
             linkerSettings: [
-                .linkedFramework("WatchConnectivity", .when(platforms: [.iOS])),
+                .linkedFramework("WatchConnectivity"),
             ]),
     ])

--- a/Package.swift
+++ b/Package.swift
@@ -18,5 +18,8 @@ let package = Package(
         .target(
             name: "MMWormhole",
             path: "Source",
-            publicHeadersPath: "."),
+            publicHeadersPath: ".",
+            linkerSettings: [
+                .linkedFramework("WatchConnectivity", .when(platforms: [.iOS])),
+            ]),
     ])

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,6 @@ import PackageDescription
 let package = Package(
     name: "MMWormhole",
     platforms: [
-        .macOS(.v10_13),
         .iOS(.v11),
         .watchOS(.v2),
     ],

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ pod 'MMWormhole', '~> 2.0.0'
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)<br/>
 MMWormhole also supports Carthage.
 
+
+### Swift Package Manager
+
+[![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
+
+MMWormhole also supports Swift Package Manager. 
+In your Xcode project, go to the Package Dependencies tab of the project settings. Add a new package by clicking on the plus sign (+), then enter the URL for this repository.
+
+
 ## Overview
 
 MMWormhole is designed to make it easy to share very basic information and commands between an extension and it's containing application. The wormhole should remain stable whether the containing app is running or not, but notifications will only be triggered in the containing app if the app is awake in the background. This makes MMWormhole ideal for cases where the containing app is already running via some form of background modes. 


### PR DESCRIPTION
## Description

This pull request adds Swift Package Manager (SPM) support to MMWormhole, enabling developers to easily integrate the MMWormhole library into their projects using SPM.

## Changes

- Added a `Package.swift` file, containing the package configuration.
- Updated the README.md to include instructions on how to integrate MMWormhole using SPM.
- Verified that existing Cocoapods and Carthage integrations are not affected.

Looking forward to your feedback.

Thank you!
